### PR TITLE
Escape regex if necessary

### DIFF
--- a/tests/testthat/test-stop.R
+++ b/tests/testthat/test-stop.R
@@ -1,4 +1,4 @@
 test_that("winch_stop() works", {
   expect_error(winch_stop("foo"), "foo")
-  expect_error(winch_stop("\u2026"), enc2native("\u2026"))
+  expect_error(winch_stop("\u2026"), enc2native(glob2rx("\u2026")))
 })

--- a/tests/testthat/test-stop.R
+++ b/tests/testthat/test-stop.R
@@ -1,4 +1,4 @@
 test_that("winch_stop() works", {
   expect_error(winch_stop("foo"), "foo")
-  expect_error(winch_stop("\u2026"), enc2native(glob2rx("\u2026")))
+  expect_error(winch_stop("\u2026"), enc2native(glob2rx("*\u2026*", trim.head = TRUE)))
 })


### PR DESCRIPTION
to fix CRAN failures.