### PR TITLE
Change semantics of rlang_trace_use_winch option

### DIFF
--- a/R/add_trace_back.R
+++ b/R/add_trace_back.R
@@ -23,6 +23,11 @@ winch_add_trace_back <- function(trace = rlang::trace_back(bottom = parent.frame
     return(trace)
   }
 
+  # Check for trace version
+  if (!identical(attr(trace, "version"), 1L)) {
+    return(trace)
+  }
+
   # Avoid recursion
   old_options <- options(rlang_trace_use_winch = NULL)
   on.exit(options(old_options))

--- a/README.Rmd
+++ b/README.Rmd
@@ -68,7 +68,7 @@ As this cannot be easily demonstrated in a knitr document, the output is copied 
 options(
   error = rlang::entrace,
   rlang_backtrace_on_error = "full",
-  rlang_trace_use_winch = 1L
+  rlang_trace_use_winch = TRUE
 )
 
 vctrs::vec_as_location(quote, 2)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Below is an example where an R function calls into C which calls back into R. No
 <span class='nf'><a href='https://rdrr.io/r/base/options.html'>options</a></span>(
   error = <span class='k'>rlang</span>::<span class='k'><a href='https://rlang.r-lib.org/reference/entrace.html'>entrace</a></span>,
   rlang_backtrace_on_error = <span class='s'>"full"</span>,
-  rlang_trace_use_winch = <span class='m'>1L</span>
+  rlang_trace_use_winch = <span class='m'>TRUE</span>
 )
 
 <span class='k'>vctrs</span>::<span class='nf'><a href='https://vctrs.r-lib.org/reference/vec_as_location.html'>vec_as_location</a></span>(<span class='k'>quote</span>, <span class='m'>2</span>)

--- a/examples/e07.R
+++ b/examples/e07.R
@@ -4,7 +4,7 @@
 
 library(winch)
 
-options(rlang_trace_use_winch = 1L)
+options(rlang_trace_use_winch = TRUE)
 
 foo <- function() {
   winch_call(bar)

--- a/examples/e08.R
+++ b/examples/e08.R
@@ -7,7 +7,7 @@ library(winch)
 options(
   error = rlang::entrace,
   rlang_backtrace_on_error = "full",
-  rlang_trace_use_winch = 1L
+  rlang_trace_use_winch = TRUE
 )
 
 foo <- function() {

--- a/examples/e11.R
+++ b/examples/e11.R
@@ -7,7 +7,7 @@ library(winch)
 options(
   error = rlang::entrace,
   rlang_backtrace_on_error = "full",
-  rlang_trace_use_winch = 1L
+  rlang_trace_use_winch = TRUE
 )
 
 foo <- function() {

--- a/examples/e12.R
+++ b/examples/e12.R
@@ -4,7 +4,7 @@
 
 library(winch)
 
-options(rlang_trace_use_winch = 1L)
+options(rlang_trace_use_winch = TRUE)
 
 foo <- function() {
   winch_call(bar)

--- a/examples/e13.R
+++ b/examples/e13.R
@@ -4,7 +4,7 @@
 
 library(winch)
 
-options(rlang_trace_use_winch = 1L)
+options(rlang_trace_use_winch = TRUE)
 
 foo <- function() {
   winch_call(bar)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,24 +1,15 @@
 DEBUG = true
 PKG_CPPFLAGS = -Ilocal/include
-
-ifeq (, $(shell ( mkdir -p build/libbacktrace && cd build/libbacktrace && CC="$(CC)" AR="$(AR)" RANLIB="$(RANLIB)" ../../vendor/libbacktrace/configure --disable-host-shared --prefix=$${PWD}/../../local ) 1>&2 && echo ok ))
-
-# Only compile if configuration is successful
 PKG_CFLAGS = -DHAVE_LIBBACKTRACE
 WINCH_LOCAL_LIBS = local/lib/libbacktrace.a
 PKG_LIBS = ${WINCH_LOCAL_LIBS}
 
-else
-
-PKG_CFLAGS =
-WINCH_LOCAL_LIBS =
-PKG_LIBS =
-
-fi
-
 all: $(SHLIB)
 
 $(SHLIB): ${WINCH_LOCAL_LIBS}
+
+build/libbacktrace/Makefile: vendor/libbacktrace/configure
+	mkdir -p build/libbacktrace && cd build/libbacktrace && CC="$(CC)" AR="$(AR)" RANLIB="$(RANLIB)" ../../vendor/libbacktrace/configure --disable-host-shared --prefix=$${PWD}/../../local
 
 local/lib/libbacktrace.a: build/libbacktrace/Makefile vendor/libbacktrace/*.c vendor/libbacktrace/*.h
 	cd build/libbacktrace && make install

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,15 +1,24 @@
 DEBUG = true
 PKG_CPPFLAGS = -Ilocal/include
+
+ifeq (, $(shell ( mkdir -p build/libbacktrace && cd build/libbacktrace && CC="$(CC)" AR="$(AR)" RANLIB="$(RANLIB)" ../../vendor/libbacktrace/configure --disable-host-shared --prefix=$${PWD}/../../local ) 1>&2 && echo ok ))
+
+# Only compile if configuration is successful
 PKG_CFLAGS = -DHAVE_LIBBACKTRACE
 WINCH_LOCAL_LIBS = local/lib/libbacktrace.a
 PKG_LIBS = ${WINCH_LOCAL_LIBS}
 
+else
+
+PKG_CFLAGS =
+WINCH_LOCAL_LIBS =
+PKG_LIBS =
+
+fi
+
 all: $(SHLIB)
 
 $(SHLIB): ${WINCH_LOCAL_LIBS}
-
-build/libbacktrace/Makefile: vendor/libbacktrace/configure
-	mkdir -p build/libbacktrace && cd build/libbacktrace && CC="$(CC)" AR="$(AR)" RANLIB="$(RANLIB)" ../../vendor/libbacktrace/configure --disable-host-shared --prefix=$${PWD}/../../local
 
 local/lib/libbacktrace.a: build/libbacktrace/Makefile vendor/libbacktrace/*.c vendor/libbacktrace/*.h
 	cd build/libbacktrace && make install

--- a/tests/example2.R
+++ b/tests/example2.R
@@ -12,7 +12,7 @@ if (winch_available() && requireNamespace("rlang")) {
   options(
     error = rlang::entrace,
     rlang_backtrace_on_error = "full",
-    rlang_trace_use_winch = 1L
+    rlang_trace_use_winch = TRUE
   )
 
   foo()

--- a/tests/example3.R
+++ b/tests/example3.R
@@ -2,7 +2,7 @@ if (winch::winch_available() && require(vctrs)) {
   options(
     error = rlang::entrace,
     rlang_backtrace_on_error = "full",
-    rlang_trace_use_winch = 1L
+    rlang_trace_use_winch = TRUE
   )
 
   winch::winch_init_library(vctrs:::vctrs_init$dll[["path"]])

--- a/tests/example4.R
+++ b/tests/example4.R
@@ -12,7 +12,7 @@ if (winch_available() && requireNamespace("rlang")) {
   options(
     error = rlang::entrace,
     rlang_backtrace_on_error = "full",
-    rlang_trace_use_winch = 1L
+    rlang_trace_use_winch = TRUE
   )
 
   foo()

--- a/tests/example5.R
+++ b/tests/example5.R
@@ -12,7 +12,7 @@ if (winch_available() && require(magrittr) && requireNamespace("rlang")) {
   options(
     error = rlang::entrace,
     rlang_backtrace_on_error = "full",
-    rlang_trace_use_winch = 1L
+    rlang_trace_use_winch = TRUE
   )
 
   foo() %>% identity()

--- a/tests/example6.R
+++ b/tests/example6.R
@@ -4,7 +4,7 @@ if (winch::winch_available() && requireNamespace("RSQLite") && requireNamespace(
   options(
     error = rlang::entrace,
     rlang_backtrace_on_error = "full",
-    rlang_trace_use_winch = 1L
+    rlang_trace_use_winch = TRUE
   )
 
   winch::winch_init_library(RSQLite:::"_RSQLite_init_logging"$dll[["path"]])

--- a/vignettes/report.Rmd
+++ b/vignettes/report.Rmd
@@ -202,7 +202,7 @@ The integration is a [small change to rlang](https://github.com/r-lib/rlang/pull
 With this option set, manual addition of the native stack trace is no longer necessary.
 
 ```{r eval = FALSE}
-options(rlang_trace_use_winch = 1L)
+options(rlang_trace_use_winch = TRUE)
 
 baz <- function() {
   rlang::trace_back()
@@ -229,7 +229,7 @@ The example below triggers an error and native code calls into R to throw the er
 options(
   error = rlang::entrace,
   rlang_backtrace_on_error = "full",
-  rlang_trace_use_winch = 1L
+  rlang_trace_use_winch = TRUE
 )
 
 vctrs::vec_as_location(quote, 2)


### PR DESCRIPTION
Only add trace for compatible version, as detected from attribute.