### PR TITLE
Use correct printf format for uintptr_t.

### DIFF
--- a/src/trace_back_backtrace.c
+++ b/src/trace_back_backtrace.c
@@ -84,7 +84,7 @@ int cb_get_name_ip(void *data, uintptr_t pc,
   R_xlen_t pos = cb_data->pos;
 
   char ip_buf[33];
-  sprintf(ip_buf, "%.16" PRIx64, pc);
+  sprintf(ip_buf, "%.16" PRIxPTR, pc);
   ip_buf[sizeof(ip_buf) / sizeof(*ip_buf) - 1] = '\0';
   SEXP chr_ip = Rf_mkCharCE(ip_buf, CE_UTF8);
   SET_STRING_ELT(out_ip, pos, chr_ip);

--- a/src/trace_back_unwind.c
+++ b/src/trace_back_unwind.c
@@ -68,7 +68,7 @@ SEXP winch_trace_back_unwind() {
     SET_STRING_ELT(out_name, i, Rf_mkCharCE(buf, CE_UTF8));
 
     char ip_buf[33];
-    sprintf(ip_buf, "%.16" PRIx64, pi.start_ip);
+    sprintf(ip_buf, "%.16" PRIxPTR, pi.start_ip);
     //snprintf(ip_buf, sizeof(ip_buf) / sizeof(buf), "%p", (void*)pi.start_ip);
     ip_buf[sizeof(ip_buf) / sizeof(*ip_buf) - 1] = '\0';
     SET_STRING_ELT(out_ip, i, Rf_mkCharCE(ip_buf, CE_UTF8));


### PR DESCRIPTION
This is fine on 64-bit systems, but warns on 32-bit systems:
```
trace_back_backtrace.c: In function 'cb_get_name_ip':
trace_back_backtrace.c:87:19: warning: format '%llx' expects argument of type 'long long unsigned int', but argument 3 has type 'uintptr_t' {aka 'unsigned int'} [-Wformat=]
   87 |   sprintf(ip_buf, "%.16" PRIx64, pc);
      |                   ^~~~~~         ~~
      |                                  |
      |                                  uintptr_t {aka unsigned int}

```
and similar for `trace_back_unwind.c`.

I'm not sure how portable this format macro is; if not, I can add a cast instead.