### PR TITLE
fix: Fix deprecation warnings

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -7,11 +7,11 @@
 #include <R_ext/Visibility.h>
 #define export attribute_visible extern
 
-extern SEXP winch_init_library();
-extern SEXP winch_trace_back();
-extern SEXP winch_trace_back_default_method();
-extern SEXP winch_call(SEXP function, SEXP env);
-extern SEXP winch_stop(SEXP message);
+SEXP winch_init_library(SEXP argv0, SEXP force);
+SEXP winch_trace_back(SEXP method); 
+SEXP winch_trace_back_default_method(void);
+SEXP winch_call(SEXP function, SEXP env);
+SEXP winch_stop(SEXP message);
 
 static const R_CallMethodDef CallEntries[] = {
   {"winch_c_init_library",                 (DL_FUNC) &winch_init_library, 2},
@@ -23,7 +23,7 @@ static const R_CallMethodDef CallEntries[] = {
   {NULL, NULL, 0}
 };
 
-extern SEXP init_backtrace(const char* argv0, int force);
+SEXP init_backtrace(const char* argv0, int force);
 
 export void R_init_winch(DllInfo *dll)
 {

--- a/src/trace_back.c
+++ b/src/trace_back.c
@@ -7,8 +7,8 @@
 #endif
 
 
-extern SEXP winch_trace_back_unwind();
-extern SEXP winch_trace_back_backtrace();
+SEXP winch_trace_back_unwind(void);
+SEXP winch_trace_back_backtrace(void);
 
 
 SEXP winch_trace_back(SEXP method) {
@@ -29,7 +29,7 @@ SEXP winch_trace_back(SEXP method) {
   }
 }
 
-SEXP winch_trace_back_default_method() {
+SEXP winch_trace_back_default_method(void) {
 #if defined(HAVE_LIBUNWIND)
   return Rf_ScalarInteger(1);
 #elif defined(HAVE_LIBBACKTRACE) && BACKTRACE_SUPPORTED

--- a/src/trace_back_backtrace.c
+++ b/src/trace_back_backtrace.c
@@ -112,7 +112,7 @@ int cb_get_name_ip(void *data, uintptr_t pc,
   return 0;
 }
 
-SEXP winch_trace_back_backtrace() {
+SEXP winch_trace_back_backtrace(void) {
   R_xlen_t size = 0;
   backtrace_full(backtrace_state, 1, cb_increment_size, cb_error, &size);
 

--- a/src/trace_back_unwind.c
+++ b/src/trace_back_unwind.c
@@ -86,7 +86,7 @@ SEXP winch_trace_back_unwind() {
 
 #else // #ifdef HAVE_LIBUNWIND
 
-SEXP winch_trace_back_unwind() {
+SEXP winch_trace_back_unwind(void) {
   Rf_error("libunwind not supported on this platform.");
 }
 


### PR DESCRIPTION
- fix compilation warnings from [logs](https://cran.r-project.org/web/checks/check_results_winch.html). Warning is `-Wstrict-prototypes`
  - remove `extern` for function - deprecated
  - fix arguments for prototypes. `void` for prototypes without arguments.