### PR TITLE
fix: Fix prototype warning

### DIFF
--- a/src/trace_back_unwind.c
+++ b/src/trace_back_unwind.c
@@ -12,7 +12,7 @@
 
 void* buf[10000];
 
-SEXP winch_trace_back_unwind() {
+SEXP winch_trace_back_unwind(void) {
   unw_context_t uc;
   memset(&uc, 0, sizeof(uc));
 


### PR DESCRIPTION
- fix `strict-prototypes` warning