### PR TITLE
chore: Fix compiler warnings

### DIFF
--- a/src/trace_back_backtrace.c
+++ b/src/trace_back_backtrace.c
@@ -85,8 +85,9 @@ int cb_get_name_ip(void *data, uintptr_t pc,
 
   char ip_buf[33];
   // Workaround for MINGW UCRT problems:
-  sprintf(
+  snprintf(
     ip_buf,
+    33,
     "%.8" PRIx32 "%.8" PRIx32,
     (uint32_t)((uint64_t)pc / 0x100000000),
     (uint32_t)((uint64_t)pc % 0x100000000)

--- a/src/trace_back_unwind.c
+++ b/src/trace_back_unwind.c
@@ -68,7 +68,7 @@ SEXP winch_trace_back_unwind(void) {
     SET_STRING_ELT(out_name, i, Rf_mkCharCE(buf, CE_UTF8));
 
     char ip_buf[33];
-    sprintf(ip_buf, "%.16" PRIxPTR, pi.start_ip);
+    snprintf(ip_buf, 33, "%.16" PRIxPTR, pi.start_ip);
     //snprintf(ip_buf, sizeof(ip_buf) / sizeof(buf), "%p", (void*)pi.start_ip);
     ip_buf[sizeof(ip_buf) / sizeof(*ip_buf) - 1] = '\0';
     SET_STRING_ELT(out_ip, i, Rf_mkCharCE(ip_buf, CE_UTF8));


### PR DESCRIPTION
- fix `sprintf` warnings