### PR TITLE
fix: Add `cleanup` script to drop in-tree libbacktrace build artifacts

### DIFF
--- a/cleanup
+++ b/cleanup
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Remove build artifacts created in the source tree by 'src/configure.sh'
+# (and by 'R CMD INSTALL', which builds the bundled libbacktrace in place).
+#
+# 'R CMD build' runs this script after installing the package to build the
+# vignettes.  Since R 4.7.0 that install happens *after* '.Rbuildignore' has
+# been applied, so the freshly created artifacts would otherwise be packaged
+# into the source tarball and flagged by 'R CMD check' (object files in a
+# source package, hidden '.libs' directory, stray 'src/Makevars').
+
+rm -rf src/build src/local
+rm -f src/Makevars
+rm -f src/*.o src/*.so src/*.dll


### PR DESCRIPTION
## Problem

The scheduled `rcc` workflow (`R-CMD-check.yaml`) has been failing daily on a single job: `rcc: ubuntu-24.04 (devel)`. Every other job (stock R, Windows-devel, macOS, and even Linux R 4.6) passes.

`R CMD check --as-cran` completes with **0 errors, 0 warnings, but 3 NOTEs**, and because that job runs with `error_on = "note"` the NOTEs fail it:

```
❯ checking if this is a source package ... NOTE
    Found the following apparent object files/libraries:
      src/build/libbacktrace/atomic.o ... src/local/lib/libbacktrace.a ...
❯ checking for hidden files and directories ... NOTE
    src/build/libbacktrace/.libs
❯ checking compilation flags in Makevars ... NOTE
    Package has both 'src/Makevars.in' and 'src/Makevars'.
```

## Root cause

`winch` builds the bundled `libbacktrace` **in-tree** via `src/configure.sh`, which creates `src/build/`, `src/local/`, and a generated `src/Makevars`. These are all listed in `.Rbuildignore`.

R 4.7.0 (R-devel) rewrote `R CMD build`'s packaging step. It now:

1. copies the sources to the build directory **applying `.Rbuildignore`**, then
2. **installs the package to build vignettes** (which runs `configure` and re-creates `src/build`, `src/local`, `src/Makevars` inside that already-filtered copy), with
3. **no subsequent `.Rbuildignore` re-filtering** before tarring.

In R ≤ 4.6, the install-for-vignettes step ran *before* the ignore filter was applied, so the artifacts were dropped from the tarball. Under R-devel they now survive into the source tarball and `R CMD check` flags them — hence the R-devel-only failure.

## Fix

Add an executable `cleanup` script (the standard R mechanism, complementary to the existing `configure`). `R CMD build` runs `cleanup` right after the vignette install and before building the tarball, removing the in-tree artifacts in time:

```sh
rm -rf src/build src/local
rm -f src/Makevars
rm -f src/*.o src/*.so src/*.dll
```

The script is POSIX-clean (`checkbashisms` passes) and version-independent — on older R it is a harmless no-op.

## Verification

Reproduced and verified locally on the exact CI R-devel build (`R Under development (unstable) (2026-06-21 r90185)`):

- **Before:** built tarball contained 47 leaked `src/build/`, `src/local/`, `src/Makevars` entries → 3 NOTEs.
- **After:** `R CMD build` logs `* running 'cleanup'`, tarball is clean, and `R CMD check --as-cran` reports **`Status: OK`** (0/0/0). The `checking if this is a source package`, `checking for hidden files and directories`, `checking compilation flags in Makevars`, and `checking top-level files` checks all report `OK`.
- No regression on stock R 4.5.3 (clean tarball, `cleanup` runs, package still ships the script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7

---
_Generated by [Claude Code](https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7)_